### PR TITLE
Refactored sound config

### DIFF
--- a/hosts/common/global/default.nix
+++ b/hosts/common/global/default.nix
@@ -191,6 +191,16 @@
     };
   };
 
+    # Enable sound with pipewire.
+  hardware.pulseaudio.enable = false;
+  security.rtkit.enable = true;
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+  };
+
   # SECURITY --------------------------
   security.polkit.enable = true; # needed for sway
   security.pam.services.swaylock = {}; # needed for swaylock

--- a/hosts/snowmachine/default.nix
+++ b/hosts/snowmachine/default.nix
@@ -32,16 +32,6 @@
     videoDrivers = [ "displayLink" "modesetting" ];
   };
 
-  # Enable sound with pipewire.
-  sound.enable = true;
-  hardware.pulseaudio.enable = false;
-  security.rtkit.enable = true;
-  services.pipewire = {
-    enable = true;
-    alsa.enable = true;
-    alsa.support32Bit = true;
-    pulse.enable = true;
-  };
 
   # SECURITY --------------------------
 

--- a/hosts/starmachine/default.nix
+++ b/hosts/starmachine/default.nix
@@ -33,16 +33,6 @@
     open = false;
   };
 
-  # Enable sound with pipewire.
-  sound.enable = false; # https://github.com/NixOS/nixpkgs/issues/319809#issuecomment-2167912680
-  hardware.pulseaudio.enable = false;
-  security.rtkit.enable = true;
-  services.pipewire = {
-    enable = true;
-    alsa.enable = true;
-    alsa.support32Bit = true;
-    pulse.enable = true;
-  };
 
   # SECURITY --------------------------
   


### PR DESCRIPTION
`starmachine` and `snowmachine` have same settings it turns out, so they didn't need separated configs.